### PR TITLE
Add ctxpack ongoing project

### DIFF
--- a/_data/profile.yml
+++ b/_data/profile.yml
@@ -502,6 +502,20 @@ research:
   - ECIES
 
 projects:
+- title: "ctxpack: Repo Context Packer"
+  link: https://github.com/thromel/ctxpack
+  date: May 2026 - Present
+  description: >-
+    Ongoing Rust project building a local-first context compiler and MCP context broker for AI coding agents. ctxpack indexes safe repository
+    context, prepares task-conditioned context plans, compiles budgeted Markdown/JSON packs, and integrates with agent-native workflows such as
+    AGENTS.md, Codex, Claude Code, Cursor, and OpenCode without becoming an autonomous editor.
+  technologies:
+  - Rust
+  - MCP
+  - Coding Agents
+  - Context Engineering
+  - Git
+  - CLI
 - title: "Blockchain-Based Ticketing Platform"
   link: /showcase/projects/blockchain-ticketing/
   date: Jan 2021 - April 2021

--- a/_showcase/projects/ctxpack.md
+++ b/_showcase/projects/ctxpack.md
@@ -1,0 +1,41 @@
+---
+layout: showcase
+title: "ctxpack: Repo Context Packer"
+subtitle: "A local-first context compiler for AI coding agents"
+category: projects
+group: Projects
+show: true
+width: 8
+date: 2026-05-10 00:00:00 +0800
+excerpt: An ongoing Rust project that turns repository tasks into compact, evidence-labeled context plans and packs for Codex, Claude Code, Cursor, OpenCode, and other MCP-compatible coding agents.
+featured: true
+technologies:
+  - Rust
+  - MCP
+  - Coding Agents
+  - Context Engineering
+  - Git
+  - CLI
+---
+
+# ctxpack: Repo Context Packer
+
+ctxpack is an ongoing local-first tool for making coding agents better at choosing repository context. Instead of becoming another chat UI or autonomous editor, it acts as a read-only context broker behind existing tools such as Codex, Claude Code, Cursor, OpenCode, and other MCP-compatible agents.
+
+The project is built around a context compiler: given a software task, it identifies likely target files, related tests, git co-change hints, validation commands, and budgeted snippets, then emits small structured plans or Markdown/JSON context packs for the agent to consume.
+
+## Current Implementation
+
+- Rust workspace with separate CLI, core contracts, index, compiler, and MCP crates.
+- Agent-native setup through `AGENTS.md`, Cursor rules, Claude command scaffolding, and OpenCode config guidance.
+- Local safe inventory that respects ignore files and excludes sensitive/generated files by default.
+- Lexical repository search, related-test detection, and git co-change hints.
+- `prepare-task` context-plan compilation with target files, related tests, validation commands, risk flags, and privacy status.
+- Materialized `get-pack` output in Markdown and JSON for brief, standard, and deep budgets.
+- MCP server exposing repo-aware `prepare_task` and `get_pack` tools.
+
+## Direction
+
+The goal is to make agents retrieve less irrelevant context, read better evidence earlier, and validate changes with the right tests. The project stays local-first and read-only by default: no cloud indexing, no cloud reranking, and no autonomous code editing.
+
+<p><a href="https://github.com/thromel/ctxpack" target="_blank">View the public repository on GitHub</a></p>


### PR DESCRIPTION
Adds ctxpack as an ongoing project in the project archive and featured showcase narrative.\n\nValidation:\n- Parsed _data/profile.yml as YAML\n- Parsed _showcase/projects/ctxpack.md front matter\n- Full Jekyll build was not run because local system Ruby is missing Bundler 4.0.2 required by Gemfile.lock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk content-only change that adds a new project entry and showcase page; main risk is minor site build/rendering issues from YAML/front-matter formatting.
> 
> **Overview**
> Adds a new project entry for **`ctxpack: Repo Context Packer`** to `_data/profile.yml`, including description, date, link, and technologies.
> 
> Introduces a featured showcase page `_showcase/projects/ctxpack.md` with front matter and narrative describing the project’s goals, current implementation, and GitHub link.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d86f945847968c026c8cbd14f7d50bbcf4a8f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->